### PR TITLE
✨♻️ [feat] 일반/기부 지갑 분리

### DIFF
--- a/src/main/java/com/wepong/pongdang/entity/WalletEntity.java
+++ b/src/main/java/com/wepong/pongdang/entity/WalletEntity.java
@@ -23,7 +23,7 @@ public class WalletEntity extends BaseEntity {
     private UserEntity user;
 
     @Enumerated(EnumType.STRING)
-    private WalletType type;
+    private WalletType walletType;
 
     @ColumnDefault("0")
     private Long pongBalance;

--- a/src/main/java/com/wepong/pongdang/entity/WalletEntity.java
+++ b/src/main/java/com/wepong/pongdang/entity/WalletEntity.java
@@ -8,6 +8,7 @@ import org.hibernate.annotations.ColumnDefault;
 
 @Entity(name = "wallet")
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/wepong/pongdang/entity/enums/RankType.java
+++ b/src/main/java/com/wepong/pongdang/entity/enums/RankType.java
@@ -1,5 +1,5 @@
 package com.wepong.pongdang.entity.enums;
 
 public enum RankType {
-    FIRST, SECOND, THIRD, LOSE
+    FIRST, SECOND, THIRD, WIN, LOSE
 }

--- a/src/main/java/com/wepong/pongdang/entity/mapping/PurchaseEntity.java
+++ b/src/main/java/com/wepong/pongdang/entity/mapping/PurchaseEntity.java
@@ -15,7 +15,7 @@ public class PurchaseEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    private Long id;
+    private String id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/wepong/pongdang/repository/RewardPerResultRepository.java
+++ b/src/main/java/com/wepong/pongdang/repository/RewardPerResultRepository.java
@@ -1,0 +1,12 @@
+package com.wepong.pongdang.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.wepong.pongdang.entity.RewardPerResultEntity;
+import com.wepong.pongdang.entity.enums.RankType;
+
+@Repository
+public interface RewardPerResultRepository extends JpaRepository<RewardPerResultEntity, Long> {
+	RewardPerResultEntity findByGameLevelIdAndRank(Long gameLevelId, RankType rank);
+}

--- a/src/main/java/com/wepong/pongdang/repository/WalletRepository.java
+++ b/src/main/java/com/wepong/pongdang/repository/WalletRepository.java
@@ -1,0 +1,12 @@
+package com.wepong.pongdang.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.wepong.pongdang.entity.WalletEntity;
+import com.wepong.pongdang.entity.enums.WalletType;
+
+@Repository
+public interface WalletRepository extends JpaRepository<WalletEntity, Long> {
+	WalletEntity findByUserIdAndWalletType(Long userId, WalletType type);
+}

--- a/src/main/java/com/wepong/pongdang/service/TurtleGameService.java
+++ b/src/main/java/com/wepong/pongdang/service/TurtleGameService.java
@@ -4,17 +4,25 @@ import com.wepong.pongdang.dto.response.GameRoomResponseDTO;
 import com.wepong.pongdang.dto.response.TurtlePlayerDTO;
 import com.wepong.pongdang.entity.GameEntity;
 import com.wepong.pongdang.entity.GameHistoryEntity;
+import com.wepong.pongdang.entity.GameLevelEntity;
+import com.wepong.pongdang.entity.GameRoomEntity;
 import com.wepong.pongdang.entity.PongHistoryEntity;
+import com.wepong.pongdang.entity.RewardPerResultEntity;
 import com.wepong.pongdang.entity.UserEntity;
+import com.wepong.pongdang.entity.WalletEntity;
+import com.wepong.pongdang.entity.enums.PongHistoryType;
 import com.wepong.pongdang.entity.enums.RankType;
-import com.wepong.pongdang.entity.enums.Level;
-import com.wepong.pongdang.entity.enums.PointHistoryType;
+import com.wepong.pongdang.entity.enums.WalletType;
 import com.wepong.pongdang.model.multi.turtle.PlayerDAO;
 import com.wepong.pongdang.model.multi.turtle.TurtleGameState;
+import com.wepong.pongdang.repository.GameRoomRepository;
+import com.wepong.pongdang.repository.RewardPerResultRepository;
 import com.wepong.pongdang.repository.UserRepository;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,33 +35,37 @@ import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class TurtleGameService {
 	
 	@Autowired
 	private PlayerDAO playerDAO;
-	@Autowired
-	private GameRoomService gameRoomService;
-	@Autowired
-	private AuthService authService;
-	@Autowired
-	private GameService gameService;
-	@Autowired
-	private HistoryService historyService;
+
+	private final GameRoomService gameRoomService;
+	private final AuthService authService;
+	private final GameService gameService;
+	private final HistoryService historyService;
 
     private final UserRepository userRepository;
+	private final RewardPerResultRepository rewardPerResultRepository;
 	
-    private final Map<String, TurtleGameState> gameStates = new ConcurrentHashMap<>();
+    private final Map<Long, TurtleGameState> gameStates = new ConcurrentHashMap<>();
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(4);
-    private final Map<String, List<TurtlePlayerDTO>> gameStartPlayersMap = new ConcurrentHashMap<>();
+    private final Map<Long, List<TurtlePlayerDTO>> gameStartPlayersMap = new ConcurrentHashMap<>();
+	@Autowired
+	private WalletService walletService;
+	@Autowired
+	private GameLevelService gameLevelService;
+	private GameRoomRepository gameRoomRepository;
 
-    // 콜백 인터페이스(핸들러에서 정의)
+	// 콜백 인터페이스(핸들러에서 정의)
     public interface RaceUpdateCallback {
-        void onRaceUpdate(String roomId, double[] positions);
-        void onRaceFinish(String roomId, int winner, List<Map<String, Object>> results);
+        void onRaceUpdate(Long roomId, double[] positions);
+        void onRaceFinish(Long roomId, int winner, List<Map<String, Object>> results);
     }
 
     // 게임 시작(레이스 시작)
-    public void startGame(String roomId, int turtleCount, RaceUpdateCallback callback) {
+    public void startGame(Long roomId, int turtleCount, RaceUpdateCallback callback) {
         TurtleGameState state = new TurtleGameState(turtleCount);
         gameStates.put(roomId, state);
         List<TurtlePlayerDTO> startPlayers = playerDAO.getAll(roomId);
@@ -65,7 +77,7 @@ public class TurtleGameService {
     }
 
     // 실제 레이스 루프(40ms마다)
-    private void runRaceLoop(String roomId, TurtleGameState state, RaceUpdateCallback callback) {
+    private void runRaceLoop(Long roomId, TurtleGameState state, RaceUpdateCallback callback) {
         int interval = 30;
         Runnable task = new Runnable() {
             @Override
@@ -85,106 +97,93 @@ public class TurtleGameService {
     }
     
     // 결과에 따른 포인트, 승패 계산
-    private List<Map<String, Object>> gameResultAndPointCalc(String roomId, TurtleGameState state) {
+    private List<Map<String, Object>> gameResultAndPointCalc(Long roomId, TurtleGameState state) {
         List<TurtlePlayerDTO> players = playerDAO.getAll(roomId);
-    	List<TurtlePlayerDTO> startPlayers = gameStartPlayersMap.get(roomId);
         GameRoomResponseDTO.GameRoomDetailDTO gameroom = gameRoomService.selectById(roomId);
-        String gameName = "Turtle Run";
-        Level difficulty = gameroom.getLevel();
+        String gameName = gameroom.getGameName();
         int winner = state.getWinner();
 
-        double userRate = 1.0;
-        switch(difficulty) {
-            case EASY: userRate = 0.2; break;
-            case NORMAL: userRate = 1.5; break;
-            case HARD: userRate = 4.0; break;
-        }
-        int winnerTurtle = winner; // 0-based
+		GameRoomEntity gameRoomEntity = gameRoomRepository.findById(roomId).orElseThrow(() -> new IllegalArgumentException("게임방이 존재하지 않습니다."));
+		GameLevelEntity gameLevel = gameRoomEntity.getGameLevel();
 
-        int totalBet = startPlayers.stream().mapToInt(TurtlePlayerDTO::getBettingPoint).sum();
-        int winPool = players.stream()
-            .filter(p -> p.getTurtleId() != null && Integer.parseInt(p.getTurtleId()) - 1 == winnerTurtle)
-            .mapToInt(TurtlePlayerDTO::getBettingPoint)
-            .sum();
-        if (winPool == 0) winPool = 1; // 0방지
+		Long gameLevelId = gameRoomEntity.getGameLevel().getId();
+		int entryFee = gameLevel.getEntryFee();
 
         // 결과 리스트 준비
         List<Map<String, Object>> results = new ArrayList<>();
 
         for (TurtlePlayerDTO player : players) {
             int selectedTurtle = player.getTurtleId() != null ? Integer.parseInt(player.getTurtleId()) - 1 : -1;
-            int userBet = player.getBettingPoint();
-            int winAmount = 0;
-            int pointChange = 0;
-            boolean didWin = (selectedTurtle == winnerTurtle);
+            boolean didWin = (selectedTurtle == winner);
 
-            if (didWin) {
-                winAmount = (int)Math.round(((double)totalBet / winPool) * userBet + userBet * userRate);
-                pointChange += winAmount;
-            } else {
-                winAmount = 0;
-                pointChange -= userBet;
-            }
-            String gameResult = didWin ? "WIN" : "LOSE";
-            saveTurtleRunResult(player.getUserUid(), userBet, winAmount, gameResult, gameName);
+			RankType gameResult = didWin ? RankType.WIN : RankType.LOSE;
+
+			RewardPerResultEntity rewardConfig = rewardPerResultRepository.findByGameLevelIdAndRank(gameLevelId, gameResult);
+
+			int reward = didWin ? rewardConfig.getReward() : 0;
+			int donation = didWin ? rewardConfig.getDonation() : 0;
+			int pongChange = didWin ? reward : -entryFee;
+
+            saveTurtleRunResult(player.getUserId(), entryFee, reward, donation, gameResult, gameName);
 
             // ✅ 각 플레이어 결과 Map 저장
             Map<String, Object> result = new HashMap<>();
-            result.put("user_uid", player.getUserUid());
+            result.put("user_uid", player.getUserId());
             result.put("selectedTurtle", selectedTurtle);
             result.put("didWin", didWin);
-            result.put("winAmount", winAmount);
-            result.put("pointChange", pointChange);
+            result.put("winAmount", reward);
+            result.put("pointChange", pongChange);
             results.add(result);
         }
         return results;
     }
     
 	 // DB 저장
-    private void saveTurtleRunResult(String userUid, int betAmount, int winAmount, String gameResult, String gameName) {
-    	UserEntity userEntity = authService.findByUid(userUid);
+    private void saveTurtleRunResult(Long userId, int entryFee, int reward, int donation, RankType gameResult, String gameName) {
+    	UserEntity userEntity = authService.findById(userId);
+		WalletEntity pongWallet = walletService.findByIdAndType(userId, WalletType.PONG);
+		WalletEntity donaWallet = walletService.findByIdAndType(userId, WalletType.DONA);
         if (userEntity != null) {
-        	 if ("WIN".equals(gameResult)) {
-     	        userEntity.setPointBalance(userEntity.getPointBalance() + winAmount);
+        	 if (gameResult.equals(RankType.WIN)) {
+				 pongWallet.setPongBalance(pongWallet.getPongBalance() + reward);
+				 donaWallet.setPongBalance(donaWallet.getPongBalance() + donation);
      	    } else {
-     	        // 이미 차감된 상태면 생략, 아니면 아래 라인 활성화
-     	         userEntity.setPointBalance(userEntity.getPointBalance() - betAmount);
+				 // 이미 차감된 상태면 생략, 아니면 아래 라인 활성화
+				 pongWallet.setPongBalance(pongWallet.getPongBalance() - entryFee);
      	    }
      	    userRepository.save(userEntity);
             // 히스토리/포인트 히스토리 등도 기록
-            String gameUid = gameService.selectByName(gameName)
+            Long gameId = gameService.selectByName(gameName)
             		.stream().findFirst()
             		.orElseThrow(() -> new IllegalStateException("'" + gameName + "' 게임을 찾을 수 없습니다."))
-            		.getUid();
+            		.getId();
 
-            GameEntity gameEntity = gameService.selectById(gameUid);
+            GameEntity gameEntity = gameService.selectById(gameId);
 
             // 게임 히스토리 저장 (gameName도 같이)
             GameHistoryEntity gameHistoryEntity = GameHistoryEntity.builder()
-                    .gameEntity(gameEntity)
-                    .bettingAmount(betAmount)
-                    .pointValue(Math.abs(winAmount - betAmount))
-                    .gameResult(RankType.valueOf(gameResult))
+                    .game(gameEntity)
+                    .entryFee(entryFee)
+                    .pongValue(reward)
+                    .rank(gameResult)
                     .build();
 
-            historyService.insertGameHistory(gameHistoryEntity, userUid);
+            historyService.insertGameHistory(gameHistoryEntity, userId);
 
             // 포인트 히스토리 저장
             PongHistoryEntity pongHistoryEntity = PongHistoryEntity.builder()
-                    .gameHistoryEntity(gameHistoryEntity)
-                    .type(PointHistoryType.valueOf(gameResult))
-                    .amount(Math.abs(winAmount - betAmount))
-                    .balanceAfter(userEntity.getPointBalance())
+                    .type(PongHistoryType.GAME)
+                    .amount(Math.abs(reward - entryFee))
                     .build();
 
-            historyService.insertPointHistory(pongHistoryEntity, userUid);
+            historyService.insertPointHistory(pongHistoryEntity, userId);
         }
     }
     
-    public TurtleGameState getGameState(String roomId) {
+    public TurtleGameState getGameState(Long roomId) {
         return gameStates.get(roomId);
     }
-    public void removeGame(String roomId) {
+    public void removeGame(Long roomId) {
         gameStates.remove(roomId);
     }
 }

--- a/src/main/java/com/wepong/pongdang/service/WalletService.java
+++ b/src/main/java/com/wepong/pongdang/service/WalletService.java
@@ -23,12 +23,12 @@ public class WalletService {
 
 	public void insertWallet(UserEntity user) {
 		WalletEntity pongWallet = WalletEntity.builder()
-			.type(WalletType.PONG)
+			.walletType(WalletType.PONG)
 			.user(user)
 			.build();
 
 		WalletEntity donaWallet = WalletEntity.builder()
-			.type(WalletType.DONA)
+			.walletType(WalletType.DONA)
 			.user(user)
 			.build();
 

--- a/src/main/java/com/wepong/pongdang/service/WalletService.java
+++ b/src/main/java/com/wepong/pongdang/service/WalletService.java
@@ -1,0 +1,62 @@
+package com.wepong.pongdang.service;
+
+import org.springframework.stereotype.Service;
+
+import com.wepong.pongdang.entity.UserEntity;
+import com.wepong.pongdang.entity.WalletEntity;
+import com.wepong.pongdang.entity.enums.WalletType;
+import com.wepong.pongdang.repository.WalletRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class WalletService {
+
+	private final WalletRepository walletRepository;
+
+	public WalletEntity findByIdAndType(Long userId, WalletType type) {
+		return walletRepository.findByUserIdAndWalletType(userId, type);
+	}
+
+	public void insertWallet(UserEntity user) {
+		WalletEntity pongWallet = WalletEntity.builder()
+			.type(WalletType.PONG)
+			.user(user)
+			.build();
+
+		WalletEntity donaWallet = WalletEntity.builder()
+			.type(WalletType.DONA)
+			.user(user)
+			.build();
+
+		walletRepository.save(pongWallet);
+		walletRepository.save(donaWallet);
+	}
+
+	public void addPong(int point, Long userId) {
+		WalletEntity pongWallet = walletRepository.findByUserIdAndWalletType(userId, WalletType.PONG);
+		pongWallet.setPongBalance(pongWallet.getPongBalance() + point);
+		walletRepository.save(pongWallet);
+	}
+
+	public void losePong(int point, Long userId) {
+		WalletEntity pongWallet = walletRepository.findByUserIdAndWalletType(userId, WalletType.PONG);
+		pongWallet.setPongBalance(pongWallet.getPongBalance() - point);
+		walletRepository.save(pongWallet);
+	}
+
+	public void addDona(int point, Long userId) {
+		WalletEntity pongWallet = walletRepository.findByUserIdAndWalletType(userId, WalletType.DONA);
+		pongWallet.setPongBalance(pongWallet.getPongBalance() + point);
+		walletRepository.save(pongWallet);
+	}
+
+	public void loseDona(int point, Long userId) {
+		WalletEntity pongWallet = walletRepository.findByUserIdAndWalletType(userId, WalletType.DONA);
+		pongWallet.setPongBalance(pongWallet.getPongBalance() - point);
+		walletRepository.save(pongWallet);
+	}
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #6 

## 📌 개요
- 일반 퐁과 기부 퐁의 지갑을 분리합니다.
- 단체게임(터틀런) 난이도에 따른 참여퐁, 보상, 기부금 결과를 저장합니다.
- 게임 우승 시, 일반 지갑: 잔액-참여퐁+보상 / 기부 지갑: 잔액+기부금
- 게임 패배 시, 일반 지갑: 잔액-참여퐁 / 기부 지갑: 변동없음
- UUID로 저장하는 id 타입을 String으로 변경합니다.

## 🔁 변경 사항
73ad6ddf1ad44612150d341742423dde58612fb7: 지갑 분리 생성
6545a259eea471fff23fb769aaf191e861ede2ed, 92df1abef2a42d25d9976b06429279cdedff179d: 단체게임 결과 리팩토링
7f89427cc28c3c0f80cbc6aa60f76ead3de99915, cea753c90c6c149dca5575824bbd99b5eda6ed97: 오류 수정

## 📸 스크린샷 (선택)
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/ca7c297c-4aa8-413b-9612-50f805044d37" />

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
