### PR TITLE
✨[feat] UserEntity 연관 엔티티 cascade 삭제 설정

### DIFF
--- a/src/main/java/com/wepong/pongdang/config/SecurityConfig.java
+++ b/src/main/java/com/wepong/pongdang/config/SecurityConfig.java
@@ -23,6 +23,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
             .requestMatchers("/api/auth/register", "/api/auth/login", "/ws/**", "/api/quizzes/**").permitAll()
             .requestMatchers("/api/auth/phone/**").permitAll()
+                            .requestMatchers("/api/game/**").permitAll()
             .requestMatchers("/api/email/**").permitAll()
             .anyRequest().authenticated()
             )

--- a/src/main/java/com/wepong/pongdang/controller/GameRestController.java
+++ b/src/main/java/com/wepong/pongdang/controller/GameRestController.java
@@ -205,4 +205,11 @@ public class GameRestController {
 	public GameLevelEntity selectLevelByRoom(@PathVariable Long levelId) {
 		return gameLevelService.selectByLevelUid(levelId);
 	}
+
+    // 게임 삭제
+    @DeleteMapping("/{gameId}")
+    public ResponseEntity<?> deleteGame(@PathVariable Long gameId) {
+        gameService.deleteGame(gameId);
+        return ResponseEntity.ok("게임이 삭제되었습니다.");
+    }
 }

--- a/src/main/java/com/wepong/pongdang/entity/BoardEntity.java
+++ b/src/main/java/com/wepong/pongdang/entity/BoardEntity.java
@@ -2,9 +2,13 @@ package com.wepong.pongdang.entity;
 
 import com.wepong.pongdang.entity.common.BaseEntity;
 import com.wepong.pongdang.entity.enums.BoardType;
+import com.wepong.pongdang.entity.mapping.ReplyEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity(name = "board")
 @Getter
@@ -41,6 +45,11 @@ public class BoardEntity extends BaseEntity {
     @JoinColumn(name = "user_id")
     private UserEntity user;
 
+    // 댓글 (1:N)
+    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ReplyEntity> replies = new ArrayList<>();
+
+
     public void incrementViewCount() {
         this.viewCount++;
     }
@@ -48,4 +57,6 @@ public class BoardEntity extends BaseEntity {
     public void incrementLikeCount() {
         this.likeCount++;
     }
+
+
 }

--- a/src/main/java/com/wepong/pongdang/entity/EmailVerificationEntity.java
+++ b/src/main/java/com/wepong/pongdang/entity/EmailVerificationEntity.java
@@ -27,6 +27,7 @@ public class EmailVerificationEntity {
     @Column(nullable = false)
     private boolean isVerified;
 
+
     public void markVerified() {
         this.isVerified = true;
     }

--- a/src/main/java/com/wepong/pongdang/entity/GameEntity.java
+++ b/src/main/java/com/wepong/pongdang/entity/GameEntity.java
@@ -6,6 +6,9 @@ import com.wepong.pongdang.entity.enums.GameType;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity(name = "game")
 @Getter
 @Setter
@@ -32,4 +35,12 @@ public class GameEntity extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private GameStatus status;
+
+    //  GameLevel (1:N)
+    @OneToMany(mappedBy = "game", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<GameLevelEntity> levels = new ArrayList<>();
+
+    //  GameHistory (1:N)
+    @OneToMany(mappedBy = "game", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<GameHistoryEntity> histories = new ArrayList<>();
 }

--- a/src/main/java/com/wepong/pongdang/entity/GameLevelEntity.java
+++ b/src/main/java/com/wepong/pongdang/entity/GameLevelEntity.java
@@ -4,6 +4,9 @@ import com.wepong.pongdang.entity.enums.Level;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity(name = "game_level")
 @Getter
 @Builder
@@ -27,4 +30,12 @@ public class GameLevelEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_id")
     private GameEntity game;
+
+    // RewardPerResult (1:N)
+    @OneToMany(mappedBy = "gameLevel", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<RewardPerResultEntity> rewards = new ArrayList<>();
+
+    // GameRoom (1:N)
+    @OneToMany(mappedBy = "gameLevel", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<GameRoomEntity> rooms = new ArrayList<>();
 }

--- a/src/main/java/com/wepong/pongdang/entity/ProductEntity.java
+++ b/src/main/java/com/wepong/pongdang/entity/ProductEntity.java
@@ -1,8 +1,12 @@
 package com.wepong.pongdang.entity;
 
 import com.wepong.pongdang.entity.common.BaseEntity;
+import com.wepong.pongdang.entity.mapping.PurchaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity(name = "product")
 @Getter
@@ -26,4 +30,7 @@ public class ProductEntity extends BaseEntity {
 
     @Column(columnDefinition = "VARCHAR(225) DEFAULT ''")
     private String img;
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<PurchaseEntity> purchases = new ArrayList<>();
 }

--- a/src/main/java/com/wepong/pongdang/entity/QuizCheckEntity.java
+++ b/src/main/java/com/wepong/pongdang/entity/QuizCheckEntity.java
@@ -21,13 +21,14 @@ public class QuizCheckEntity extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 간단히 userId만 저장 (연관관계 매핑이 필요하면 @ManyToOne으로 변경)
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
-
     @Column(name = "quiz_date", nullable = false)
     private LocalDate quizDate;
 
     @Column(nullable = false)
     private boolean taken = false;            // 제출 여부
+
+    //  유저 연관관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
 }

--- a/src/main/java/com/wepong/pongdang/entity/UserEntity.java
+++ b/src/main/java/com/wepong/pongdang/entity/UserEntity.java
@@ -1,11 +1,16 @@
 package com.wepong.pongdang.entity;
 
 import com.wepong.pongdang.entity.common.BaseEntity;
+import com.wepong.pongdang.entity.mapping.DonationEntity;
+import com.wepong.pongdang.entity.mapping.PurchaseEntity;
+import com.wepong.pongdang.entity.mapping.ReplyEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.sql.Date;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity(name = "user") // 테이블 이름
 @Getter
@@ -52,7 +57,41 @@ public class UserEntity extends BaseEntity {
 
     // Wallet 관계 (1:N)
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private java.util.List<WalletEntity> wallets = new java.util.ArrayList<>();
+    private List<WalletEntity> wallets = new ArrayList<>();
+
+    // 포인트 기록 (1:N)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<PongHistoryEntity> pongHistories = new ArrayList<>();
+
+    // 게임 이력 (1:N)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<GameHistoryEntity> gameHistories = new ArrayList<>();
+
+    // 구매 이력 (1:N)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<PurchaseEntity> purchases = new ArrayList<>();
+
+
+    // 기부 (1:N)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<DonationEntity> donations = new ArrayList<>();
+
+    // 퀴즈 기록 (1:N)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<QuizCheckEntity> quizChecks = new ArrayList<>();
+
+    // 게시글 (1:N)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<BoardEntity> boards = new ArrayList<>();
+
+    // 댓글 (1:N)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ReplyEntity> replies = new ArrayList<>();
+
+    // 챗봇 로그 (1:N)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ChatLogsEntity> chatLogs = new ArrayList<>();
+
 
     public void updatePassword(String password) {
         this.password = password;

--- a/src/main/java/com/wepong/pongdang/repository/PhoneVerificationRepository.java
+++ b/src/main/java/com/wepong/pongdang/repository/PhoneVerificationRepository.java
@@ -12,4 +12,7 @@ public interface PhoneVerificationRepository extends JpaRepository<PhoneVerifica
 
     // 특정 전화번호 + 인증번호로 조회 (검증할 때 유용)
     PhoneVerificationEntity findByPhoneNumberAndVerificationCode(String phoneNumber, String verificationCode);
+    
+    //삭제
+    void deleteByPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/com/wepong/pongdang/repository/VerificationRepository.java
+++ b/src/main/java/com/wepong/pongdang/repository/VerificationRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface VerificationRepository extends JpaRepository<EmailVerificationEntity, String> {
+    void deleteByEmail(String email);
 }

--- a/src/main/java/com/wepong/pongdang/service/AuthService.java
+++ b/src/main/java/com/wepong/pongdang/service/AuthService.java
@@ -7,9 +7,7 @@ import com.wepong.pongdang.entity.AuthTokenEntity;
 import com.wepong.pongdang.entity.UserEntity;
 import com.wepong.pongdang.exception.*;
 import com.wepong.pongdang.model.aws.S3FileServiceReturnKey;
-import com.wepong.pongdang.repository.TokenRepository;
-import com.wepong.pongdang.repository.UserRepository;
-import com.wepong.pongdang.repository.WalletRepository;
+import com.wepong.pongdang.repository.*;
 import com.wepong.pongdang.util.JWTUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +32,9 @@ public class AuthService {
 	private final WalletRepository walletRepository;
 	private final WalletService walletService;
 
+
+    private final PhoneVerificationRepository phoneVerificationRepository;
+    private final VerificationRepository verificationRepository;
 	@Autowired
 	private JWTUtil jwtUtil;
 	
@@ -48,6 +49,8 @@ public class AuthService {
 		
 		UserEntity userEntity = userRepository.findByEmail(request.getEmail());
 		AuthTokenEntity token = tokenRepository.findByUserId(userEntity.getId());
+
+
 
 		if (userEntity == null) {
 			throw new UserNotFoundException();
@@ -131,7 +134,7 @@ public class AuthService {
 				.nickname(dto.getNickname())
 				.email(dto.getEmail())
 				.birthDate(birthDate)
-				.phoneNumber(dto.getPhoneNumber())
+				.phoneNumber(dto.getPhoneNumber().replaceAll("-", ""))
 				.agreePrivacy(dto.isAgreePrivacy())
                 .tutorialCheck(false)
 				.build();
@@ -235,6 +238,12 @@ public class AuthService {
                 s3FileService.deleteObject(key);
             }
         }
+
+        // 휴대폰 인증 삭제
+        phoneVerificationRepository.deleteByPhoneNumber(userEntity.getPhoneNumber());
+
+        // 이메일 인증 삭제
+        verificationRepository.deleteByEmail(userEntity.getEmail());
 
         //  유저 삭제 → AuthToken, Wallet 은 cascade 로 같이 삭제됨
         userRepository.delete(userEntity);

--- a/src/main/java/com/wepong/pongdang/service/GameService.java
+++ b/src/main/java/com/wepong/pongdang/service/GameService.java
@@ -35,6 +35,14 @@ public class GameService {
     public List<GameEntity> selectByName(String name) {
 		  return gameRepository.findByName(name);
 	  }
+
+    //삭제
+    @Transactional
+    public void deleteGame(Long gameId) {
+        GameEntity game = gameRepository.findById(gameId)
+                .orElseThrow(() -> new IllegalArgumentException("게임을 찾을 수 없습니다. ID=" + gameId));
+        gameRepository.delete(game);
+    }
 }
 	 
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #16 

## 📌 개요
- UserEntity 에 cascade 설정을 추가하여 관련 엔티티(게시판, 게임 이력, 포인트 이력, 기부, 퀴즈 기록, 댓글, 구매, 인증, 챗로그, 결제 등)를 회원 탈퇴 시 함께 삭제되도록 처리

## 🔁 변경 사항
UserEntity에 cascade 설정 추가 (게시판, 게임내역, 포인트내역, 기부, 퀴즈체크, 댓글, 구매, 인증, 챗로그, 결제 등)
AuthService 회원탈퇴 수정(회원 탈퇴 시 email_verification / phone_verification 데이터 함께 삭제되도록 처리)
회원가입(register) 로직에서 전화번호 하이픈 제거 후 DB 저장하도록 수정
## 📸 스크린샷 (선택)

## 👀 기타 더 이야기해볼 점 (선택)

## 💬 리뷰 요구사항 (선택)

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
