### PR TITLE
✨ [feat] 보드게임 활동 로그(알림) 전송

### DIFF
--- a/src/main/java/com/wepong/pongdang/controller/BoardGameController.java
+++ b/src/main/java/com/wepong/pongdang/controller/BoardGameController.java
@@ -11,6 +11,7 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Controller;
 
+import java.util.List;
 import java.util.Map;
 
 @Controller
@@ -30,6 +31,12 @@ public class BoardGameController {
 
         // 랜덤 색상 세팅
         boardPlayerService.setRandomTurtle(userId, roomId);
+
+        // 턴 세팅
+        List<BoardPlayerDTO> players = boardPlayerService.getPlayers(roomId);
+        for (int i = 0; i < players.size(); i++) {
+            players.get(i).setTurnOrder(i);
+        }
 
         // RoomState, Land 메모리 생성 후 전송
         boardGameService.startGame(roomId, gameType);
@@ -109,13 +116,21 @@ public class BoardGameController {
 
     // 금고/월급
     @MessageMapping("/salary/{roomId}")
-        public void handleSalary(@DestinationVariable Long roomId,
-                               @Payload Map<String, Object> payload,
-                               SimpMessageHeaderAccessor accessor) {
+    public void handleSalary(@DestinationVariable Long roomId,
+                           @Payload Map<String, Object> payload,
+                           SimpMessageHeaderAccessor accessor) {
         Long userId = (Long) accessor.getSessionAttributes().get("userId");
         String gameType = (String) accessor.getSessionAttributes().get("gameType");
 
         int landId = (int) payload.get("land_id");
         boardGameService.salary(roomId, userId, landId, gameType);
+    }
+
+    // 턴 종료
+    @MessageMapping("/turn/{roomId}")
+    public void handleTurn(@DestinationVariable Long roomId,
+                           SimpMessageHeaderAccessor accessor) {
+        String gameType = (String) accessor.getSessionAttributes().get("gameType");
+        boardGameService.endTurn(roomId, gameType);
     }
 }

--- a/src/main/java/com/wepong/pongdang/controller/BoardGameController.java
+++ b/src/main/java/com/wepong/pongdang/controller/BoardGameController.java
@@ -44,7 +44,7 @@ public class BoardGameController {
         String gameType = (String) accessor.getSessionAttributes().get("gameType");
 
         int dice = (int) payload.get("dice");
-        boolean isDouble = (boolean) payload.get("isDouble");
+        boolean isDouble = (boolean) payload.get("is_double");
         boardGameService.roll(roomId, userId, dice, isDouble, gameType);
     }
 
@@ -56,7 +56,7 @@ public class BoardGameController {
         Long userId = (Long) accessor.getSessionAttributes().get("userId");
         String gameType = (String) accessor.getSessionAttributes().get("gameType");
 
-        int landId = (int) payload.get("landId");
+        int landId = (int) payload.get("land_id");
         boardGameService.purchase(roomId, userId, landId, gameType);
     }
 
@@ -68,7 +68,7 @@ public class BoardGameController {
         Long userId = (Long) accessor.getSessionAttributes().get("userId");
         String gameType = (String) accessor.getSessionAttributes().get("gameType");
 
-        int landId = (int) payload.get("landId");
+        int landId = (int) payload.get("land_id");
         boardGameService.toll(roomId, userId, landId, gameType);
     }
 
@@ -90,8 +90,8 @@ public class BoardGameController {
         Long userId = (Long) accessor.getSessionAttributes().get("userId");
         String gameType = (String) accessor.getSessionAttributes().get("gameType");
 
-        int selectIdx = (int) payload.get("selectIdx");
-        boolean isCorrect = (boolean) payload.get("isCorrect");
+        int selectIdx = (int) payload.get("select_idx");
+        boolean isCorrect = (boolean) payload.get("is_correct");
         boardGameService.quiz(roomId, userId, selectIdx, isCorrect, gameType);
     }
 
@@ -103,7 +103,7 @@ public class BoardGameController {
         Long userId = (Long) accessor.getSessionAttributes().get("userId");
         String gameType = (String) accessor.getSessionAttributes().get("gameType");
 
-        int landId = (int) payload.get("landId");
+        int landId = (int) payload.get("land_id");
         boardGameService.bank(roomId, userId, landId, gameType);
     }
 
@@ -115,7 +115,7 @@ public class BoardGameController {
         Long userId = (Long) accessor.getSessionAttributes().get("userId");
         String gameType = (String) accessor.getSessionAttributes().get("gameType");
 
-        int landId = (int) payload.get("landId");
+        int landId = (int) payload.get("land_id");
         boardGameService.salary(roomId, userId, landId, gameType);
     }
 }

--- a/src/main/java/com/wepong/pongdang/dto/response/GameRoomResponseDTO.java
+++ b/src/main/java/com/wepong/pongdang/dto/response/GameRoomResponseDTO.java
@@ -49,7 +49,7 @@ public class GameRoomResponseDTO {
 		private String gameType;
 		private int count;
 
-		public static GameRoomDetailDTO from(GameRoomEntity room, int count) {
+		public static GameRoomDetailDTO from(GameRoomEntity room, int count, String gameType) {
 			return GameRoomDetailDTO.builder()
 					.id(room.getId())
 					.title(room.getTitle())
@@ -61,6 +61,7 @@ public class GameRoomResponseDTO {
 					.hostId(room.getUser().getId())
 					.createdAt(room.getCreatedAt())
 					.status(room.getStatus())
+					.gameType(gameType)
 					.build();
 		}
 

--- a/src/main/java/com/wepong/pongdang/model/multi/board/BoardGameService.java
+++ b/src/main/java/com/wepong/pongdang/model/multi/board/BoardGameService.java
@@ -257,6 +257,13 @@ public class BoardGameService {
                     land.setOwnerId(null);
                 }
             }
+
+            // 파산 인원 확인
+            List<BoardPlayerDTO> players = boardPlayerService.getPlayers(roomId);
+            long active = players.stream().filter(BoardPlayerDTO::isActive).count();
+            if(active <= 1) {
+                endGame(roomId, "board");
+            }
         }
     }
 

--- a/src/main/java/com/wepong/pongdang/model/multi/board/BoardGameService.java
+++ b/src/main/java/com/wepong/pongdang/model/multi/board/BoardGameService.java
@@ -108,17 +108,32 @@ public class BoardGameService {
 
         if(player.isSkipTurn() && !isDouble) {
             player.setSkipTurn(false);
+
+            Map<String, Object> msg = new HashMap<>();
+            msg.put("message", player.getNickname()+"님 탈출 실패!\uD83C\uDFDD\uFE0F");
+
+            webSocketService.sendGame(roomId, "prison", gameType, msg);
+
             endTurn(roomId, gameType);
             return;
         }
 
+        String result = String.valueOf(dice);
         if(isDouble) {
             roomState.setDouble(true);
             roomState.setDoubleCount(roomState.getDoubleCount() + 1);
+            result = dice+"(더블)";
+
             if(roomState.getDoubleCount() >= 3) {
                 player.setSkipTurn(true);
                 player.setPosition(6);
                 roomState.setDouble(false);
+
+                Map<String, Object> msg = new HashMap<>();
+                msg.put("players", boardPlayerService.getPlayers(roomId));
+                msg.put("message", player.getNickname()+"님이 무인도에 갇혔습니다!\uD83C\uDFDD\uFE0F");
+
+                webSocketService.sendGame(roomId, "prison", gameType, msg);
 
                 endTurn(roomId, gameType);
                 return;
@@ -128,20 +143,38 @@ public class BoardGameService {
             roomState.setDoubleCount(0);
         }
 
+        int startPos = player.getPosition();
         int position = (player.getPosition() + dice) % 24;
         player.setPosition(position);
-
-        if (position == 6) {
-            player.setSkipTurn(true);
-        }
 
         roomState.setDouble(isDouble);
 
         Map<String, Object> data = new HashMap<>();
         data.put("players", boardPlayerService.getPlayers(roomId));
         data.put("roomState", roomState);
+        data.put("message", player.getNickname()+"님이 "+result+"칸 이동!\uD83C\uDFB2");
 
         webSocketService.sendGame(roomId, "roll", gameType, data);
+
+        if(position < startPos) {
+            player.setBalance(player.getBalance() + 15);
+
+            Map<String, Object> msg = new HashMap<>();
+            msg.put("players", boardPlayerService.getPlayers(roomId));
+            msg.put("message", player.getNickname()+"님이 월급 획득!\uD83D\uDCB5");
+
+            webSocketService.sendGame(roomId, "salary", gameType, msg);
+        }
+
+        if (position == 6) {
+            player.setSkipTurn(true);
+
+            Map<String, Object> msg = new HashMap<>();
+            msg.put("message", player.getNickname()+"님이 무인도에 갇혔습니다!\uD83C\uDFDD\uFE0F");
+
+            webSocketService.sendGame(roomId, "prison", gameType, msg);
+            endTurn(roomId, gameType);
+        }
     }
 
     // 통행료 지급
@@ -160,6 +193,7 @@ public class BoardGameService {
         Map<String, Object> data = new HashMap<>();
         data.put("players", boardPlayerService.getPlayers(roomId));
         data.put("lands", landService.getLands(roomId));
+        data.put("message", player.getNickname()+"님이 "+owner.getNickname()+"님 에게 "+land.getToll()+"원 지불 완료!\uD83D\uDCB0");
 
         webSocketService.sendGame(roomId, "toll", gameType, data);
 
@@ -179,6 +213,7 @@ public class BoardGameService {
         Map<String, Object> data = new HashMap<>();
         data.put("players", boardPlayerService.getPlayers(roomId));
         data.put("lands", landService.getLand(roomId, landId));
+        data.put("message", player.getNickname()+"님이 "+land.getName()+" 구매!\uD83D\uDC5B");
 
         webSocketService.sendGame(roomId, "purchase", gameType, data);
 
@@ -204,6 +239,8 @@ public class BoardGameService {
         data.put("players", boardPlayerService.getPlayers(roomId));
         data.put("roomState", roomStateService.getState(roomId));
         data.put("lands", landService.getLands(roomId));
+        data.put("message", player.getNickname()+"님이 "+land.getToll()+"원 지불 완료!\uD83D\uDCB0");
+
 
         webSocketService.sendGame(roomId, "tax", gameType, data);
 
@@ -225,20 +262,17 @@ public class BoardGameService {
 
     // 월급/금고
     public void salary(Long roomId, Long userId, int landId, String gameType) {
-        LandDTO land = landService.getLand(roomId, landId);
         BoardPlayerDTO player = boardPlayerService.getPlayer(roomId, userId);
 
-        if(land.getLandId() == 0) { // 월급
-            player.setBalance(player.getBalance() + land.getToll());
-        } else { // 금고 초기화
-            RoomStateDTO roomState = roomStateService.getState(roomId);
-            player.setBalance(player.getBalance() + roomState.getPot());
-            roomState.setPot(0);
-        }
+        RoomStateDTO roomState = roomStateService.getState(roomId);
+        int amount = roomState.getPot();
+        player.setBalance(player.getBalance() + amount);
+        roomState.setPot(0);
 
         Map<String, Object> data = new HashMap<>();
         data.put("players", boardPlayerService.getPlayers(roomId));
         data.put("roomState", roomStateService.getState(roomId));
+        data.put("message", player.getNickname()+"님이 "+amount+"원 획득!\uD83D\uDCB0");
 
         webSocketService.sendGame(roomId, "salary", gameType, data);
 
@@ -248,6 +282,10 @@ public class BoardGameService {
     public void endTurn(Long roomId, String gameType) {
         RoomStateDTO roomState = roomStateService.getState(roomId);
         List<BoardPlayerDTO> players = boardPlayerService.getPlayers(roomId);
+
+        if(roomState.isDouble()) {
+            return;
+        }
 
         int nextTurn = (roomState.getCurrentTurn() + 1) % players.size();
 
@@ -267,7 +305,11 @@ public class BoardGameService {
         roomState.setCurrentTurn(nextTurn);
         roomState.setDouble(false);
 
-        webSocketService.sendGame(roomId, "turn_end", gameType, roomState);
+        Map<String, Object> data = new HashMap<>();
+        data.put("roomState", roomState);
+        data.put("message", players.get(nextTurn).getNickname()+" 턴!\uD83D\uDC4B");
+
+        webSocketService.sendGame(roomId, "turn_end", gameType, data);
     }
 
     public void endGame(Long roomId, String gameType) {
@@ -315,6 +357,7 @@ public class BoardGameService {
         data.put("selectIdx", selectIdx);
         data.put("isCorrect", isCorrect);
         data.put("lands", landService.getLands(roomId));
+        data.put("message", player.getNickname()+"님의 퀴즈 결과는? "+(isCorrect ? "성공!\uD83C\uDF89" : "실패!\uD83D\uDCA9"));
 
         webSocketService.sendGame(roomId, "quiz_check", gameType, data);
 

--- a/src/main/java/com/wepong/pongdang/model/multi/board/BoardPlayerService.java
+++ b/src/main/java/com/wepong/pongdang/model/multi/board/BoardPlayerService.java
@@ -28,9 +28,6 @@ public class BoardPlayerService {
     public void enterPlayer(Long roomId, Long userId) {
         UserEntity user = authService.findById(userId);
 
-        List<BoardPlayerDTO> players = getPlayers(roomId);
-        int turnOrder = (players != null) ? players.size() : 0;
-
         BoardPlayerDTO player = BoardPlayerDTO.builder()
                 .userId(userId)
                 .nickname(user.getNickname())
@@ -38,7 +35,6 @@ public class BoardPlayerService {
                 .isReady(false)
                 .balance(80)
                 .position(0)
-                .turnOrder(turnOrder)
                 .skipTurn(false)
                 .active(true)
                 .build();

--- a/src/main/java/com/wepong/pongdang/model/multi/turtle/TurtleGameService.java
+++ b/src/main/java/com/wepong/pongdang/model/multi/turtle/TurtleGameService.java
@@ -298,15 +298,12 @@ public class TurtleGameService {
 
     public void broadcastRaceFinish(Long roomId, List<Map<String, Object>> results, String gameType) {
         webSocketService.sendGame(roomId, "race_finish", gameType, results);
-
-        // 게임 종료 상태
-        gameFinishMap.put(roomId, true);
+        removeGame(roomId);
     }
 
     public void removeGame(Long roomId) {
         startTurtlePlayersMap.remove(roomId);
         gameFinishMap.remove(roomId);
-        gameRoomService.deleteRoom(roomId);
         gameStates.remove(roomId);
 
         ScheduledFuture<?> task = broadcastTasks.remove(roomId);

--- a/src/main/java/com/wepong/pongdang/service/GameRoomService.java
+++ b/src/main/java/com/wepong/pongdang/service/GameRoomService.java
@@ -49,7 +49,14 @@ public class GameRoomService {
 							(boardPlayerService.getPlayers(room.getId()) != null ?
 									boardPlayerService.getPlayers(room.getId()).size() : 0);
 
-					return GameRoomResponseDTO.GameRoomDetailDTO.from(room, count);
+					String gameType = null;
+					if(gameEntity.getName().equals("Turtle Run")) {
+						gameType = "turtle";
+					} else if(gameEntity.getName().equals("Pong Marble")) {
+						gameType = "board";
+					}
+
+					return GameRoomResponseDTO.GameRoomDetailDTO.from(room, count, gameType);
 				});
 
 		return GameRoomResponseDTO.GameRoomListDTO.from(details);
@@ -65,7 +72,15 @@ public class GameRoomService {
 							turtlePlayerService.getPlayers(room.getId()).size() :
 							(boardPlayerService.getPlayers(room.getId()) != null ?
 									boardPlayerService.getPlayers(room.getId()).size() : 0);
-					return GameRoomResponseDTO.GameRoomDetailDTO.from(room, count);
+
+					String gameType = null;
+					if(gameEntity.getName().equals("Turtle Run")) {
+						gameType = "turtle";
+					} else if(gameEntity.getName().equals("Pong Marble")) {
+						gameType = "board";
+					}
+
+					return GameRoomResponseDTO.GameRoomDetailDTO.from(room, count, gameType);
 				}).collect(Collectors.toList());
 
 		return details;

--- a/src/main/java/com/wepong/pongdang/service/GameRoomService.java
+++ b/src/main/java/com/wepong/pongdang/service/GameRoomService.java
@@ -8,7 +8,9 @@ import com.wepong.pongdang.entity.GameRoomEntity;
 import com.wepong.pongdang.entity.UserEntity;
 import com.wepong.pongdang.entity.enums.GameRoomStatus;
 import com.wepong.pongdang.exception.RoomNotFoundException;
+import com.wepong.pongdang.model.multi.board.BoardPlayerService;
 import com.wepong.pongdang.model.multi.turtle.TurtlePlayerDAO;
+import com.wepong.pongdang.model.multi.turtle.TurtlePlayerService;
 import com.wepong.pongdang.repository.GameRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -30,6 +32,8 @@ public class GameRoomService {
 	private final AuthService authService;
 	private final GameService gameService;
 	private final GameLevelService gameLevelService;
+	private final BoardPlayerService boardPlayerService;
+	private final TurtlePlayerService turtlePlayerService;
 
 	public GameRoomResponseDTO.GameRoomListDTO selectAll(int page) {
 		int size = 6;
@@ -40,7 +44,10 @@ public class GameRoomService {
 				.map(room -> {
 					GameLevelEntity level = gameLevelService.selectByLevelUid(room.getGameLevel().getId());
 					GameEntity gameEntity = level != null ? gameService.selectById(level.getGame().getId()) : null;
-					int count = turtlePlayerDAO.getAll(room.getId()) != null ? turtlePlayerDAO.getAll(room.getId()).size() : 0;
+					int count = (turtlePlayerService.getPlayers(room.getId()) != null) ?
+							turtlePlayerService.getPlayers(room.getId()).size() :
+							(boardPlayerService.getPlayers(room.getId()) != null ?
+									boardPlayerService.getPlayers(room.getId()).size() : 0);
 
 					return GameRoomResponseDTO.GameRoomDetailDTO.from(room, count);
 				});
@@ -54,7 +61,10 @@ public class GameRoomService {
 				room -> {
 					GameLevelEntity level = gameLevelService.selectByLevelUid(room.getGameLevel().getId());
 					GameEntity gameEntity = level != null ? gameService.selectById(level.getGame().getId()) : null;
-					int count = turtlePlayerDAO.getAll(room.getId()) != null ? turtlePlayerDAO.getAll(room.getId()).size() : 0;
+					int count = (turtlePlayerService.getPlayers(room.getId()) != null) ?
+							turtlePlayerService.getPlayers(room.getId()).size() :
+							(boardPlayerService.getPlayers(room.getId()) != null ?
+									boardPlayerService.getPlayers(room.getId()).size() : 0);
 					return GameRoomResponseDTO.GameRoomDetailDTO.from(room, count);
 				}).collect(Collectors.toList());
 

--- a/src/main/java/com/wepong/pongdang/socket/StompEventListener.java
+++ b/src/main/java/com/wepong/pongdang/socket/StompEventListener.java
@@ -43,7 +43,7 @@ public class StompEventListener {
         String type = (String) accessor.getSessionAttributes().get("type");
 
         // 게임 대기방 리스트 연결 시
-        if(type.equals("list")) {
+        if(type == null || type.equals("list")) {
             return;
         }
 
@@ -117,7 +117,7 @@ public class StompEventListener {
         String gameType = (String) accessor.getSessionAttributes().get("gameType");
 
         // 게임 대기방 리스트 연결 종료 시
-        if(type.equals("list")) {
+        if(type == null || type.equals("list")) {
             return;
         }
 
@@ -161,6 +161,7 @@ public class StompEventListener {
 
                     } else {
                         turtleGameService.removeGame(roomId);
+                        gameRoomService.deleteRoom(roomId);
                         webSocketService.sendList(gameRoomService.selectAll());
                     }
                 }
@@ -192,23 +193,25 @@ public class StompEventListener {
                 webSocketService.sendRoom(roomId, "exit", gameType, players);
             }
         } else if("boardgame".equals(type)) {
-            List<BoardPlayerDTO> players;
-            if(!status.equals(GameRoomStatus.WAITING)) {
-                boardGameService.processUserLose(roomId, userId);
-
-                boardPlayerService.exitPlayer(roomId, userId);
-                players = boardPlayerService.getPlayers(roomId);
-
-                if (userId.equals(gameroom.getHostId())) {
-                    if (players != null && !players.isEmpty()) {
-                        Long hostId = players.get(0).getUserId();
-                        gameRoomService.updateHost(roomId, hostId);
-
-                    } else {
-                        turtleGameService.removeGame(roomId);
-                        webSocketService.sendList(gameRoomService.selectAll());
-                    }
-                }
+//            List<BoardPlayerDTO> players;
+//            if(!status.equals(GameRoomStatus.WAITING)) {
+//                boardGameService.processUserLose(roomId, userId);
+//
+//                boardPlayerService.exitPlayer(roomId, userId);
+//                players = boardPlayerService.getPlayers(roomId);
+//
+//                if (userId.equals(gameroom.getHostId())) {
+//                    if (players != null && !players.isEmpty()) {
+//                        Long hostId = players.get(0).getUserId();
+//                        gameRoomService.updateHost(roomId, hostId);
+//
+//                    } else {
+//                        gameRoomService.deleteRoom(roomId);
+//                        webSocketService.sendList(gameRoomService.selectAll());
+//                    }
+//                }
+//
+//                webSocketService.sendGame(roomId, "exit", gameType, players);
 
                 if(!event.getCloseStatus().equals(CloseStatus.NORMAL)) {
                     Map<String, Object> msg = new HashMap<>();
@@ -216,8 +219,8 @@ public class StompEventListener {
                     msg.put("targetUrl", "/game/rooms");
                     webSocketService.sendGame(roomId, "force_exit", gameType, msg);
                 }
-            }
+//            }
         }
-        webSocketService.sendList(gameRoomService.selectAll());
+//        webSocketService.sendList(gameRoomService.selectAll());
     }
 }

--- a/src/main/java/com/wepong/pongdang/socket/StompEventListener.java
+++ b/src/main/java/com/wepong/pongdang/socket/StompEventListener.java
@@ -193,25 +193,34 @@ public class StompEventListener {
                 webSocketService.sendRoom(roomId, "exit", gameType, players);
             }
         } else if("boardgame".equals(type)) {
-//            List<BoardPlayerDTO> players;
-//            if(!status.equals(GameRoomStatus.WAITING)) {
-//                boardGameService.processUserLose(roomId, userId);
-//
-//                boardPlayerService.exitPlayer(roomId, userId);
-//                players = boardPlayerService.getPlayers(roomId);
-//
-//                if (userId.equals(gameroom.getHostId())) {
-//                    if (players != null && !players.isEmpty()) {
-//                        Long hostId = players.get(0).getUserId();
-//                        gameRoomService.updateHost(roomId, hostId);
-//
-//                    } else {
-//                        gameRoomService.deleteRoom(roomId);
-//                        webSocketService.sendList(gameRoomService.selectAll());
-//                    }
-//                }
-//
-//                webSocketService.sendGame(roomId, "exit", gameType, players);
+            List<BoardPlayerDTO> players;
+            if(!status.equals(GameRoomStatus.WAITING)) {
+                boardGameService.processUserLose(roomId, userId);
+
+                boardPlayerService.exitPlayer(roomId, userId);
+                BoardPlayerDTO player = boardPlayerService.getPlayer(roomId, userId);
+                players = boardPlayerService.getPlayers(roomId);
+
+                if(players.size() <= 1) {
+                    boardGameService.endGame(roomId, gameType);
+                }
+
+                if (userId.equals(gameroom.getHostId())) {
+                    if (players != null && !players.isEmpty()) {
+                        Long hostId = players.get(0).getUserId();
+                        gameRoomService.updateHost(roomId, hostId);
+
+                    } else {
+                        gameRoomService.deleteRoom(roomId);
+                        webSocketService.sendList(gameRoomService.selectAll());
+                    }
+                }
+
+                Map<String, Object> data = new HashMap<>();
+                data.put("players", players);
+                data.put("message", player.getNickname()+"님 퇴장!\uD83D\uDEAA");
+
+                webSocketService.sendGame(roomId, "exit", gameType, data);
 
                 if(!event.getCloseStatus().equals(CloseStatus.NORMAL)) {
                     Map<String, Object> msg = new HashMap<>();
@@ -219,8 +228,8 @@ public class StompEventListener {
                     msg.put("targetUrl", "/game/rooms");
                     webSocketService.sendGame(roomId, "force_exit", gameType, msg);
                 }
-//            }
+            }
         }
-//        webSocketService.sendList(gameRoomService.selectAll());
+        webSocketService.sendList(gameRoomService.selectAll());
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #85 

## 📌 개요
- 보드게임에서 플레이어가 플레이한 활동 로그를 웹소켓으로 전송합니다.
- 보드게임 턴 종료 요청을 추가합니다.
- 턴 순서 배정 시점 수정 및 플레이어 1인 이하 시 게임을 종료합니다.

## 🔁 변경 사항
d861800b936319db446f25e18a9db2791d0f4d83: 턴 종료 요청
5a12d680a22af8ff7be319a46569ef6f63351f79: 활동 로그 전송
b3b66d28649b9f7a96ec9d88940043a16e3441dc, fc8b6e87c4042f00c68b994e2d92f9ef9bc5d3f9: 보드게임 수정

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
